### PR TITLE
Add setup.py to allow installation via pip or easy_install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *~
 .~
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+install_requires = []
+try:
+    import json
+except ImportError:
+    install_requires.append('simplejson')
+
+try:
+    import unittest2
+except ImportError:
+    install_requires.append('unittest2')
+
+setup(
+    name="txlib",
+    author="Indifex Ltd.",
+    author_email="info@indifex.com",
+    description="A python library for Transifex",
+    url="http://www.indifex.com",
+
+    packages=find_packages(),
+    install_requires = install_requires,
+
+    keywords = (
+        'translation',
+        'localization',
+        'internationalization',
+    ),
+    license='LGPL3',
+)


### PR DESCRIPTION
setup.py is required to make distutils based-tools work; this commit adds one with minimal metadata and the appropriate dependencies.

When this is present a txlib.egg-info directory may be generated when creating a distribution. .gitignore is also updated to ignore this.
