### PR TITLE
Don't include extraneous URL fields in the create payload

### DIFF
--- a/txlib/api/base.py
+++ b/txlib/api/base.py
@@ -106,7 +106,8 @@ class BaseModel(object):
         """Create a resource in the remote Tx server."""
         path = self._construct_path_to_collection()
         for field in self.url_fields:
-            kwargs[field] = getattr(self, field)
+            if field in self.mandatory_fields:
+                kwargs[field] = getattr(self, field)
         return self._http.post(path, json.dumps(kwargs))
 
     def _update(self, **kwargs):


### PR DESCRIPTION
Some API resources, such as Resources, have url parameters (ie,
project_slug) which should not be included in the creation payload.
This change only includes them when they are mandatory fields (ie, the
slug).
