### PR TITLE
Use pytest instead of unittest

### DIFF
--- a/txlib/api/tests/test_base_model.py
+++ b/txlib/api/tests/test_base_model.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import unittest
+import pytest
 from txlib.api.base import BaseModel
 
 
-class TestBaseModel(unittest.TestCase):
+class TestBaseModel():
     """Test the base model for the Tx model wrappers."""
 
     def test_join_subpaths(self):
@@ -13,15 +13,15 @@ class TestBaseModel(unittest.TestCase):
 
         # all subpaths have slashes
         path = b._join_subpaths('/api/', '/2/', '/projects/')
-        self.assertEquals(path.count('/'), 4)
-        self.assertEquals(path, correct_path)
+        assert path.count('/') == 4
+        assert path == correct_path
 
         # none subpath has slashes
         path = b._join_subpaths('/api', '2', 'projects/')
-        self.assertEquals(path.count('/'), 4)
-        self.assertEquals(path, correct_path)
+        assert path.count('/') == 4
+        assert path == correct_path
 
         # there are some slashes
         path = b._join_subpaths('/api/', '2/', 'projects/')
-        self.assertEquals(path.count('/'), 4)
-        self.assertEquals(path, correct_path)
+        assert path.count('/') == 4
+        assert path == correct_path

--- a/txlib/http/tests/test_auth.py
+++ b/txlib/http/tests/test_auth.py
@@ -1,30 +1,33 @@
 # -*- coding: utf-8 -*-
-import unittest
+import pytest
 
 from txlib.http.auth import AuthInfo, BasicAuth, AnonymousAuth
 
 
-class TestAuthInfo(unittest.TestCase):
+class TestAuthInfo():
     """Tests for the AuthInfo class."""
 
     def test_anonymous(self):
         """Test the anonymous user."""
         username, password = None, None
         auth_info = AuthInfo.get(username, password)
-        self.assertIsInstance(auth_info, AnonymousAuth)
+        assert isinstance(auth_info, AnonymousAuth)
         req_args = {'foo': 'bar', }
         updated_req_args = auth_info.populate_request_data(req_args)
-        self.assertEqual(req_args, updated_req_args)
+        assert req_args == updated_req_args
 
     def test_authenticated(self):
         username, password = 'username', 'password'
         auth_info = AuthInfo.get(username=username, password=password)
-        self.assertIsInstance(auth_info, BasicAuth)
+        assert isinstance(auth_info, BasicAuth)
         req_args = {'foo': 'bar'}
         updated_req_args = auth_info.populate_request_data(req_args)
-        self.assertIn('foo', updated_req_args)
-        self.assertIn('auth', updated_req_args)
+        assert 'foo' in updated_req_args
+        assert 'auth' in updated_req_args
 
     def test_invalid_auth(self):
-        self.assertRaises(ValueError, AuthInfo.get, username='username')
-        self.assertRaises(ValueError, AuthInfo.get, password='password')
+        with pytest.raises(ValueError):
+            AuthInfo.get(username='username')
+
+        with pytest.raises(ValueError):
+            AuthInfo.get(password='password')

--- a/txlib/registry/tests/test_registry.py
+++ b/txlib/registry/tests/test_registry.py
@@ -1,25 +1,23 @@
 # -*- coding: utf-8 -*-
-import unittest
+import pytest
 
 from txlib.registry.registry import _Registry
 from txlib.http.auth import AnonymousAuth, BasicAuth
 
 
-class TestRegistry(unittest.TestCase):
+class TestRegistry():
     """Tests for the Registry class."""
 
-    @classmethod
-    def setUpClass(cls):
+    @pytest.fixture(autouse=True)
+    def auto_init(self):
         """Save the default responsibilities of the registry."""
-        cls.default_responsibilities = _Registry.responsibilities.copy()
-
-    def setUp(self):
+        self.default_responsibilities = _Registry.responsibilities.copy()
         self.r = _Registry()
         self.r.responsibilities = self.default_responsibilities.copy()
 
     def test_get_unknown_responsibility(self):
         """Test wrong responsibilities."""
-        self.assertIs(self.r.wrong, None)
+        assert self.r.wrong is None
 
     def test_get_responsibility(self):
         """Test fetching the class for a responsibility."""
@@ -28,17 +26,19 @@ class TestRegistry(unittest.TestCase):
             pass
 
         self.r.responsibilities['test'] = TestResponsibility
-        self.assertIs(self.r.test, TestResponsibility)
+        assert self.r.test is TestResponsibility
 
     def test_setup(self):
         """Test the setup of a responsibility object."""
         self.r.setup({'new': 'new'})
-        self.assertEquals(len(self.r.responsibilities.keys()), 1)
-        self.assertEquals(self.r.new, 'new')
+        assert len(self.r.responsibilities.keys()) == 1
+        assert self.r.new == 'new'
+
         self.r.setup({'auth_class': AnonymousAuth})
-        self.assertEquals(len(self.r.responsibilities.keys()), 2)
-        self.assertEquals(self.r.auth_class, AnonymousAuth)
+        assert len(self.r.responsibilities.keys()) == 2
+        assert self.r.auth_class == AnonymousAuth
+
         self.r.setup({'auth_class': BasicAuth, 'newnew': 'newnew'})
-        self.assertEquals(len(self.r.responsibilities.keys()), 3)
-        self.assertEquals(self.r.auth_class, BasicAuth)
-        self.assertEquals(self.r.newnew, 'newnew')
+        assert len(self.r.responsibilities.keys()) == 3
+        assert self.r.auth_class == BasicAuth
+        assert self.r.newnew == 'newnew'


### PR DESCRIPTION
Rewrote all tests so that they use pytest. It' simpler, it's better and it makes sense to do this update now, before we write more tests.