### PR TITLE
Fix support for translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .~
 *.egg-info
 .cache/
+.pytest_cache/
 .coverage
 .tox/
 test-results

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,37 @@ do the following:
     r.content = '...'
     r.save()
 
+
 Translations
 ~~~~~~~~~~~~
 
-TODO
+Get translation
+^^^^^^^^^^^^^^^
+.. code:: python
+
+    from txlib.api.translations import Translation
+    from txlib.http.exceptions import NotFoundError, ServerError
+
+    try:
+        t = Translation.get(project_slug='project_slug', slug='resource_slug', lang='translation_language')
+        print(t.lang) # 'translation_language'
+    except NotFoundError:
+        print('Translation not found')
+    except ServerError as e:
+        print('Exception while retrieving translation: {}'.format(e))
+
+
+Create/update translation
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: python
+
+    from txlib.api.translations import Translation
+    from txlib.http.exceptions import NotFoundError, ServerError
+
+    try:
+        t = Translation(
+            project_slug=project_slug, slug=resource_slug, lang=language_code
+        )
+        t.save(content=content)
+    except ServerError as e:
+        print('Exception while retrieving translation: {}'.format(e))

--- a/txlib/api/tests/test_translation.py
+++ b/txlib/api/tests/test_translation.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from txlib.api.translations import Translation
+from txlib.tests.compat import patch
+from txlib.api.tests.utils import clean_registry, get_mock_response
+
+
+@pytest.fixture(scope='module', autouse=True)
+def auto_clean_registry():
+    """Run the test and the remove the `http_handler` entry from
+    the registry."""
+    yield
+    clean_registry()
+
+
+class TestTranslationModel():
+    """Test the functionality of the Translation model."""
+
+    @patch('txlib.http.http_requests.requests.request')
+    def test_get_translation(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            200, u'{"content": {"Master_key": "τεστ"}}'
+        )
+        obj = Translation.get(project_slug='project1', slug='resource1', lang='el')
+        assert obj.lang == 'el'
+        assert obj.content == {'Master_key': u'τεστ'}
+
+    @patch('txlib.http.http_requests.requests.request')
+    def test_put_translation(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            200, '{\
+                    "strings_added": 1,\
+                    "strings_updated": 0,\
+                    "strings_delete": 0,\
+                    "redirect": ""\
+                  }'
+        )
+        content = {
+            'Master_key': 'τεστ'
+        }
+        translation = Translation(
+            project_slug='project1', slug='resource1', lang='el'
+        )
+        translation.save(content=content)
+        assert translation.lang == 'el'
+        assert translation.content == {'Master_key': 'τεστ'}
+
+

--- a/txlib/api/translations.py
+++ b/txlib/api/translations.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 
 from txlib.api.base import BaseModel
 
@@ -7,7 +8,26 @@ class Translation(BaseModel):
     """Model class for translations."""
 
     _path_to_item = 'project/%(project_slug)s/resource/%(slug)s/translation/%(lang)s'  # noqa
-    _path_to_collection = None
+    _path_to_collection = 'project/%(project_slug)s/resource/'\
+                          '%(slug)s/translation/%(lang)s'
 
     writable_fields = {'content'}
     url_fields = {'project_slug', 'slug', 'lang'}
+
+    def _create(self, **kwargs):
+        """Create the translation of a resource.
+
+        The _create function differentiates from the one in the BaseModel
+        in the HTTP request that takes place in the end. In the Translation
+        object's case, it needs to be `PUT`, while in the BaseModel is `POST`
+        """
+        path = self._construct_path_to_collection()
+
+        # Use the fields for which we have values
+        for field in self.writable_fields:
+            try:
+                value = getattr(self, field)
+                kwargs[field] = value
+            except AttributeError:
+                pass
+        return self._http.put(path, json.dumps(kwargs))


### PR DESCRIPTION
API requests for creating/updating a translation were failing due to a missing path and a wrong http method used. Added tests and updated the README file.