### PR TITLE
Resource creation now supports metadata

### DIFF
--- a/txlib/api/resources.py
+++ b/txlib/api/resources.py
@@ -19,7 +19,8 @@ class Resource(BaseModel):
 
     writable_fields = {
         'slug', 'name', 'accept_translations', 'source_language',
-        'mimetype', 'content', 'i18n_type',
+        'mimetype', 'content', 'i18n_type', 'categories', 'category',
+        'metadata',
     }
     url_fields = {'project_slug', 'slug'}
 


### PR DESCRIPTION
Resource POST requests can now include a JSON-serialized metadata field. This is only supported upon resource creation. Updates do not currently support metadata manipulation.
