### PR TITLE
Enable custom headers to http requests

### DIFF
--- a/txlib/http/auth.py
+++ b/txlib/http/auth.py
@@ -11,7 +11,7 @@ class AuthInfo(object):
     """Base class for all AuthInfo classes."""
 
     @classmethod
-    def get(self, username=None, password=None):
+    def get(self, username=None, password=None, headers={}):
         """Factory method to get the correct AuthInfo object.
 
         The returned value depends on the arguments given. In case the
@@ -22,14 +22,15 @@ class AuthInfo(object):
         Args:
             `username`: The username of the user.
             `password`: The password of the user.
+            `headers`: Custom headers to be sent to each request.
         Raises:
             ValueError in case one of the two arguments evaluates to False,
             (such as having the None value).
         """
         if all((username, password, )):
-            return BasicAuth(username, password)
+            return BasicAuth(username, password, headers)
         elif not any((username, password, )):
-            return AnonymousAuth()
+            return AnonymousAuth(headers)
         else:
             if username is None:
                 data = ("username", username, )
@@ -54,10 +55,21 @@ class AuthInfo(object):
 class BasicAuth(AuthInfo):
     """Class for basic authentication support."""
 
-    def __init__(self, username, password):
-        """Initializer."""
+    def __init__(self, username, password, headers={}):
+        """Initializer.
+
+        :param str username: The username to be used for the authentication with
+            Transifex. It can either have the value 'API' (suggested) or the
+            username of a user
+        :param str password: The password to be used for the authentication with
+            Transifex. It should be a Transifex token (suggested) if the username is
+            'API', or the password of the user whose username is used for authentication
+        :param dict headers: A dictionary with custom headers which will be sent
+            in every request to the Transifex API.
+        """
         self._username = username
         self._password = password
+        self._headers = headers
 
     def populate_request_data(self, request_args):
         """Add the authentication info to the supplied dictionary.
@@ -76,3 +88,11 @@ class BasicAuth(AuthInfo):
 
 class AnonymousAuth(AuthInfo):
     """Class for anonymous access."""
+
+    def __init__(self, headers={}):
+        """Initializer.
+
+        :param dict headers: A dictionary with custom headers which will be sent
+            in every request to the Transifex API.
+        """
+        self._headers = headers

--- a/txlib/http/http_requests.py
+++ b/txlib/http/http_requests.py
@@ -99,6 +99,11 @@ class HttpRequest(BaseRequest):
         _logger.debug("URL for request is %s" % url)
         self._auth_info.populate_request_data(kwargs)
         _logger.debug("The arguments are %s" % kwargs)
+
+        # Add custom headers for the request
+        if self._auth_info._headers:
+            kwargs.setdefault('headers', {}).update(self._auth_info._headers)
+
         res = requests.request(method, url, data=data, **kwargs)
 
         if res.ok:

--- a/txlib/http/tests/test_auth.py
+++ b/txlib/http/tests/test_auth.py
@@ -15,6 +15,15 @@ class TestAuthInfo():
         req_args = {'foo': 'bar', }
         updated_req_args = auth_info.populate_request_data(req_args)
         assert req_args == updated_req_args
+        assert auth_info._headers == {}
+
+    def test_anonymous_with_headers(self):
+        """Test the anonymous user with custom headers."""
+        username, password = None, None
+        headers = {'test-header-1': 'test-value-1', 'test-header-2': 'test-value-2'}
+        auth_info = AuthInfo.get(username=username, password=password, headers=headers)
+        assert isinstance(auth_info, AnonymousAuth)
+        assert auth_info._headers == headers
 
     def test_authenticated(self):
         username, password = 'username', 'password'
@@ -24,7 +33,15 @@ class TestAuthInfo():
         updated_req_args = auth_info.populate_request_data(req_args)
         assert 'foo' in updated_req_args
         assert 'auth' in updated_req_args
+        assert auth_info._headers == {}
 
+    def test_authenticated_with_headers(self):
+        username, password = 'username', 'password'
+        headers = {'test-header-1': 'test-value-1', 'test-header-2': 'test-value-2'}
+        auth_info = AuthInfo.get(username=username, password=password, headers=headers)
+        assert isinstance(auth_info, BasicAuth)
+        assert auth_info._headers == headers
+        
     def test_invalid_auth(self):
         with pytest.raises(ValueError):
             AuthInfo.get(username='username')


### PR DESCRIPTION
Add the ability to auth classes to include custom headers in their requests with the Transifex API.