### PR TITLE
Fix upload of resource binary files

### DIFF
--- a/txlib/api/tests/test_translation.py
+++ b/txlib/api/tests/test_translation.py
@@ -36,14 +36,31 @@ class TestTranslationModel():
                     "redirect": ""\
                   }'
         )
-        content = {
-            'Master_key': 'τεστ'
-        }
+        content = 'string1\\nstring2\\nstring3'
         translation = Translation(
             project_slug='project1', slug='resource1', lang='el'
         )
         translation.save(content=content)
         assert translation.lang == 'el'
-        assert translation.content == {'Master_key': 'τεστ'}
+        assert translation.content == content
+
+    @patch('txlib.http.http_requests.requests.request')
+    @patch('txlib.http.http_requests.HttpRequest.put')
+    def test_put_translation_binary(self, mock_put, mock_req):
+        """Test that a binary translation file calls put method."""
+        mock_req.return_value = get_mock_response(
+            200, '{\
+                            "project_slug": "project1",\
+                            "slug": "resource1",\
+                            "lang": "en",\
+                            "i18n_type": "XLSX"\
+                          }'
+        )
+
+        translation = Translation(
+            project_slug='project1', slug='resource1', lang='el'
+        )
+        translation.save(content=b'string1\\nstring2\\nstring3\\nstring4')
+        assert mock_put.called
 
 

--- a/txlib/api/translations.py
+++ b/txlib/api/translations.py
@@ -22,12 +22,21 @@ class Translation(BaseModel):
         object's case, it needs to be `PUT`, while in the BaseModel is `POST`
         """
         path = self._construct_path_to_collection()
+        content = kwargs['content']
+        is_binary = not isinstance(content, str)
 
         # Use the fields for which we have values
         for field in self.writable_fields:
             try:
                 value = getattr(self, field)
                 kwargs[field] = value
+                # on binary files pass the content as a separate parameter (not in kwargs)
+                if field == 'content' and is_binary:
+                    kwargs.pop('content', None)
             except AttributeError:
                 pass
+
+        if is_binary:
+            return self._http.put(path, kwargs, content)
+
         return self._http.put(path, json.dumps(kwargs))


### PR DESCRIPTION
HttpRequest._send_file() method is fixed to allow for binary file up-
loads. Also the BaseModel class was changed to identify if a piece of
data is binary and function accordingly.