### PR TITLE
Add method to retrieve resource stats

### DIFF
--- a/txlib/api/resources.py
+++ b/txlib/api/resources.py
@@ -16,6 +16,7 @@ class Resource(BaseModel):
     _path_to_item = 'project/%(project_slug)s/resource/%(slug)s/?details'
     _path_to_source_language = 'project/%(project_slug)s/resource/' \
                                '%(slug)s/content/'
+    _path_to_stats = 'project/%(project_slug)s/resource/%(slug)s/stats/'
 
     writable_fields = {
         'slug', 'name', 'accept_translations', 'source_language',
@@ -30,6 +31,48 @@ class Resource(BaseModel):
         res = self._http.get(path)
         self._populated_fields['content'] = res['content']
         return res['content']
+
+    def get_stats(self):
+        """Get the resource stats.
+
+        It calls the stats endpoint:
+        https://docs.transifex.com/api/statistics
+
+        and receives a response body in the following form:
+        {
+            "el": {
+                "proofread": 9,
+                "proofread_percentage": "75%",
+                "reviewed_percentage": "75%",
+                "completed": "91%",
+                "untranslated_words": 1,
+                "last_commiter": "iannos",
+                "reviewed": 9,
+                "translated_entities": 11,
+                "translated_words": 11,
+                "last_update": "2019-09-02 12:26:55",
+                "untranslated_entities": 1
+            },
+            "en": {
+                "proofread": 0,
+                "proofread_percentage": "0%",
+                "reviewed_percentage": "0%",
+                "completed": "100%",
+                "untranslated_words": 0,
+                "last_commiter": "iannos",
+                "reviewed": 0,
+                "translated_entities": 12,
+                "translated_words": 12,
+                "last_update": "2019-09-02 12:26:55",
+                "untranslated_entities": 0
+            },
+            ...
+        }
+        """
+        path = self._construct_path_to_stats()
+        res = self._http.get(path)
+        self._populated_fields['stats'] = res
+        return res
 
     def _create(self, **kwargs):
         """Create a resource in the remote Transifex server."""
@@ -74,6 +117,15 @@ class Resource(BaseModel):
     def get_path_to_source_content_template(self):
         """Return the path to the source language content."""
         return self._join_subpaths(self._prefix, self._path_to_source_language)
+
+    def _construct_path_to_stats(self):
+        """Construct the path to the resource stats."""
+        template = self.get_path_to_stats_template()  # flake8 fix
+        return template % self.get_url_parameters()
+
+    def get_path_to_stats_template(self):
+        """Return the path to the resource stats."""
+        return self._join_subpaths(self._prefix, self._path_to_stats)
 
     def __str__(self):
         return '[Resource slug={}]'.format(self.slug)

--- a/txlib/api/tests/test_resource.py
+++ b/txlib/api/tests/test_resource.py
@@ -42,6 +42,19 @@ class TestResourceModel():
         assert content == 'string1\nstring2\nstring3'
 
     @patch('txlib.http.http_requests.requests.request')
+    def test_get_stats(self, mock_request):
+        mock_request.return_value = get_mock_response(
+            200, '{"id": 100, "slug": "resource1"}'
+        )
+        resource = Resource.get(project_slug='project1', slug='resource1')
+
+        mock_request.return_value = get_mock_response(
+            200, '{"el": {"completed": "91%"}}'
+        )
+        stats = resource.get_stats()
+        assert stats == {"el": {"completed": "91%"}}
+
+    @patch('txlib.http.http_requests.requests.request')
     def test_save_content(self, mock_request):
         some_content = 'string1\\nstring2\\nstring3'
         mock_request.return_value = get_mock_response(


### PR DESCRIPTION
Added Resource.get_stats method to retrieve resource stats and store
in 'stats' field.

It calls the [stats endpoint](https://docs.transifex.com/api/statistics)

and receives a response body in the following form:
```
        {
            "el": {
                "proofread": 9,
                "proofread_percentage": "75%",
                "reviewed_percentage": "75%",
                "completed": "91%",
                "untranslated_words": 1,
                "last_commiter": "iannos",
                "reviewed": 9,
                "translated_entities": 11,
                "translated_words": 11,
                "last_update": "2019-09-02 12:26:55",
                "untranslated_entities": 1
            },
            "en": {
                "proofread": 0,
                "proofread_percentage": "0%",
                "reviewed_percentage": "0%",
                "completed": "100%",
                "untranslated_words": 0,
                "last_commiter": "iannos",
                "reviewed": 0,
                "translated_entities": 12,
                "translated_words": 12,
                "last_update": "2019-09-02 12:26:55",
                "untranslated_entities": 0
            },
            ...
        }
```