### PR TITLE
Support query params in GET requests

### DIFF
--- a/txlib/api/base.py
+++ b/txlib/api/base.py
@@ -114,6 +114,10 @@ class BaseModel(object):
         of the request, so that a particular entry of this model
         is identified and retrieved.
 
+        You can also specify a `params` dictionary in `kwargs`
+        which will contain additional query parameters to be used in the
+        request, e.g. `GET https://some.url?param1=3&param2=4
+
         Raises:
             AttributeError: if not all values for parameters in `url_fields`
                 are passed as kwargs
@@ -255,7 +259,7 @@ class BaseModel(object):
     def _get(self, **kwargs):
         """Get the resource from a remote Transifex server."""
         path = self._construct_path_to_item()
-        return self._http.get(path)
+        return self._http.get(path, params=kwargs.pop('params', None))
 
     def _create(self, **kwargs):
         """Create a resource in the remote Transifex server."""

--- a/txlib/http/http_requests.py
+++ b/txlib/http/http_requests.py
@@ -14,7 +14,7 @@ class HttpRequest(BaseRequest):
     This class can handle both HTTP and HTTPS requests.
     """
 
-    def get(self, path):
+    def get(self, path, params=None):
         """Make a GET request.
 
         Args:
@@ -24,7 +24,7 @@ class HttpRequest(BaseRequest):
         Raises:
             An exception depending on the HTTP status code of the response.
         """
-        return json.loads(self._make_request('GET', path))
+        return json.loads(self._make_request('GET', path, params=params))
 
     def post(self, path, data, content=None):
         """Make a POST request.
@@ -80,7 +80,7 @@ class HttpRequest(BaseRequest):
         """
         return self._make_request('DELETE', path)
 
-    def _make_request(self, method, path, data=None, **kwargs):
+    def _make_request(self, method, path, data=None, params=None, **kwargs):
         """Make a request.
 
         Use the `requests` module to actually perform the request.
@@ -105,7 +105,7 @@ class HttpRequest(BaseRequest):
         if self._auth_info._headers:
             kwargs.setdefault('headers', {}).update(self._auth_info._headers)
 
-        res = requests.request(method, url, data=data, **kwargs)
+        res = requests.request(method, url, data=data, params=params, **kwargs)
 
         if res.ok:
             _logger.debug("Request was successful.")


### PR DESCRIPTION
This adds support for query parameters in GET requests, forwarding any parameters given to `requests.get(params=<given_params>)`.
